### PR TITLE
Update to v0.10.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,18 +11,20 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: true  # [py<37]
   entry_points:
     - huggingface-cli=huggingface_hub.commands.huggingface_cli:main
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
+    - python
     - pip
-    - python >=3.6.0
+    - setuptools
+    - wheel
   run:
+    - python
     - filelock
-    - python >=3.6.0
     - pyyaml
     - packaging >=20.9
     - requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,16 @@ test:
 
 about:
   home: https://github.com/huggingface/huggingface_hub
-  summary: Client library to download and publish models on the huggingface.co hub
+  summary: Client library to download and publish models, datasets and other repos on the huggingface.co hub
+  description: |
+    The huggingface_hub is a client library to interact with the Hugging Face Hub. The Hugging Face Hub is a platform with over 35K models, 4K datasets, and 2K demos in which people can easily collaborate in their ML workflows. The Hub works as a central place where anyone can share, explore, discover, and experiment with open-source Machine Learning.
+
+    With huggingface_hub, you can easily download and upload models, datasets, and Spaces. You can extract useful information from the Hub, and do much more. Some example use cases:
+
+    - Downloading and caching files from a Hub repository.
+    - Creating repositories and uploading an updated model every few epochs.
+    - Extract metadata from all models that match certain criteria (e.g. models for text-classification).
+    - List all files from a specific repository.
   license: Apache-2.0
   license_file: LICENSE
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,12 @@ about:
     - List all files from a specific repository.
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
+  license_url: https://github.com/huggingface/huggingface_hub/blob/main/LICENSE
+  doc_url: https://huggingface.co/docs/hub/index
+  doc_source_url: https://github.com/huggingface/hub-docs/tree/main/docs/hub
+  dev_url: https://github.com/huggingface/huggingface_hub
+
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,13 +25,12 @@ requirements:
   run:
     - python
     - filelock
-    - pyyaml
-    - packaging >=20.9
     - requests
     - tqdm
+    - pyyaml >=5.1
     - typing-extensions >=3.7.4.3
-    # Only required for [py<38] but always include so this can be noarch: python
-    - importlib_metadata
+    - importlib-metadata  # [py<38]
+    - packaging >=20.9
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "huggingface_hub" %}
-{% set version = "0.2.1" %}
-
+{% set version = "0.10.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/huggingface_hub-{{ version }}.tar.gz
-  sha256: b2ef718ea108f0927118b80bef90bef2dd4ddb84454f2dc33267d90de8d33886
+  sha256: 5c188d5b16bec4b78449f8681f9975ff9d321c16046cc29bcf0d7e464ff29276
 
 build:
   number: 0


### PR DESCRIPTION
Update `huggingface_hub-feedstock` to `v0.10.1

https://github.com/huggingface/huggingface_hub/tree/v0.10.1

- Update version + SHA
- Update dependencies + pinnings
- Update `About`

