### PR TITLE
0.20.3 Update

### DIFF
--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,2 +1,3 @@
 channels:
     psteyer: transformers-test
+upload_without_merge: True

--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+    psteyer: transformers-test

--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-    psteyer: transformers-test
-upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "huggingface_hub" %}
-{% set version = "0.17.3" %}
+{% set version = "0.20.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 40439632b211311f788964602bf8b0d9d6b7a2314fba4e8d67b2ce3ecea0e3fd
+  sha256: 94e7f8e074475fbc67d6a71957b678e1b4a74ff1b64a644fd6cbb83da962d05d
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<38]
   entry_points:
     - huggingface-cli=huggingface_hub.commands.huggingface_cli:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
@@ -25,8 +25,7 @@ requirements:
   run:
     - python
     - filelock
-    - fsspec
-    - importlib-metadata  # [py<38]
+    - fsspec >=2023.5.0
     - packaging >=20.9
     - pyyaml >=5.1
     - requests
@@ -36,6 +35,8 @@ requirements:
     - fastai >=2.4
     - fastcore >=1.3.27
     - InquirerPy ==0.3.4
+    - pydantic >1.1,<3.0  # [py>38]
+    - pydantic >1.1,<2.0  # [py==38]
 
 test:
   imports:


### PR DESCRIPTION
Minor version update from `0.17.3` -> `0.20.3`

Dependency update for `transformers` to resolve CVE-2023-7018 and CVE-2023-6730.

Jira: https://anaconda.atlassian.net/browse/PKG-3827

 [`huggingface_hub`](https://github.com/AnacondaRecipes/huggingface_hub-feedstock/pull/6) -> [`transformers`](https://github.com/AnacondaRecipes/transformers-feedstock/pull/10)

### Changes:
- version number
- SHA
- added `ffspec`
- added `psydantic`
- changed `skip: true # [py<37]` -> `skip: true # [py<38]`