### PR TITLE
PKG-5562: Update huggingface_hub to 0.24.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "huggingface_hub" %}
-{% set version = "0.23.1" %}
+{% set version = "0.24.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4f62dbf6ae94f400c6d3419485e52bce510591432a5248a65d0cb72e4d479eb4
+  sha256: cc2579e761d070713eaa9c323e3debe39d5b464ae3a7261c39a9195b27bb8000
 
 build:
   number: 0


### PR DESCRIPTION
huggingface_hub 0.24.6

**Destination channel:** defaults

### Links

- [PKG-5562](https://anaconda.atlassian.net/browse/PKG-5562) 
- [Upstream repository](https://pypi.org/project/huggingface-hub/)
- [Upstream changelog/diff](https://pypi.org/project/huggingface-hub/#history)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/transformers-feedstock/pull/13
### Explanation of changes:

- Update to version 0.24.6 


[PKG-5562]: https://anaconda.atlassian.net/browse/PKG-5562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ