### PR TITLE
v0.29.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "huggingface_hub" %}
-{% set version = "0.24.6" %}
+{% set version = "0.29.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cc2579e761d070713eaa9c323e3debe39d5b464ae3a7261c39a9195b27bb8000
+  sha256: 590b29c0dcbd0ee4b7b023714dc1ad8563fe4a68a91463438b74e980d28afaf3
 
 build:
   number: 0
@@ -34,8 +34,6 @@ requirements:
   run_constrained:
     # cli
     - inquirerpy ==0.3.4
-    # inference
-    - minijinja >=1.0
     # hf_transfer
     - hf_transfer>=0.1.4
     # fastai


### PR DESCRIPTION
huggingface_hub v0.29.2

**Destination channel:**  defaults

### Links

- [PKG-7156](https://anaconda.atlassian.net/browse/PKG-7156) 
- [Upstream repository](https://github.com/huggingface/huggingface_hub/tree/v0.29.2)

### Explanation of changes:

- Bump version and SHA
- Build for 3.13
- Remove dependency no longer listed upstream. 


[PKG-7156]: https://anaconda.atlassian.net/browse/PKG-7156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ